### PR TITLE
✏️ Correct a small typo where the wrong default choice is shown

### DIFF
--- a/klib.py
+++ b/klib.py
@@ -5,7 +5,7 @@ try:
     from py_mini_racer import py_mini_racer
     import requests
 except ModuleNotFoundError:
-    if "y" in input("Install dependencies? [Y/n] > ").lower():
+    if "y" in input("Install dependencies? [y/N] > ").lower():
         os.system('python3 -m pip install -r requirements.txt')
 
 import asyncio


### PR DESCRIPTION
If you type nothing, `y` will not be in the input text. It's probably better to have it default to No anyway, since some people will use venvs